### PR TITLE
白魔武士优化

### DIFF
--- a/XIVAutoAttack/Combos/Basic/WHMCombo_Base.cs
+++ b/XIVAutoAttack/Combos/Basic/WHMCombo_Base.cs
@@ -1,8 +1,10 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
+using System.Linq;
 using XIVAutoAttack.Actions.BaseAction;
 using XIVAutoAttack.Combos.CustomCombo;
 using XIVAutoAttack.Data;
+using XIVAutoAttack.Helpers;
 
 namespace XIVAutoAttack.Combos.Basic;
 
@@ -99,10 +101,7 @@ internal abstract class WHMCombo_Base<TCmd> : CustomCombo<TCmd> where TCmd : Enu
     /// <summary>
     /// 庇护所
     /// </summary>
-    public static BaseAction Asylum { get; } = new(ActionID.Asylum, true, isTimeline: true)
-    {
-        ActionCheck = b => !IsMoving
-    };
+    public static BaseAction Asylum { get; } = new(ActionID.Asylum, true, isTimeline: true);
 
     /// <summary>
     /// 安慰之心
@@ -120,7 +119,14 @@ internal abstract class WHMCombo_Base<TCmd> : CustomCombo<TCmd> where TCmd : Enu
     /// <summary>
     /// 神祝祷
     /// </summary>
-    public static BaseAction DivineBenison { get; } = new(ActionID.DivineBenison, true, isTimeline: true);
+    public static BaseAction DivineBenison { get; } = new(ActionID.DivineBenison, true, isTimeline: true)
+    {
+        BuffsProvide = new StatusID[] {StatusID.DivineBenison},
+        ChoiceTarget = Targets =>
+        {
+            return TargetFilter.FindAttackedTarget(Targets.GetJobCategory(JobRole.Tank));
+        }
+    };
 
     /// <summary>
     /// 狂喜之心

--- a/XIVAutoAttack/Combos/Healer/WHMCombos/WHMCombo_Default.cs
+++ b/XIVAutoAttack/Combos/Healer/WHMCombos/WHMCombo_Default.cs
@@ -25,13 +25,13 @@ internal sealed class WHMCombo_Default : WHMCombo_Base<CommandType>
 
     private protected override ActionConfiguration CreateConfiguration()
     {
-        return base.CreateConfiguration().SetBool("UseLilyWhenFull", true, "蓝花集满时自动释放蓝花")
-                                            .SetBool("UsePreRegen", false, "开始5秒时给t上盾和再生");
+        return base.CreateConfiguration().SetBool("UseLilyWhenFull", true, "蓝花集满时自动释放蓝花（低于苦难之心等级时不会生效）")
+                                            .SetBool("UsePreRegen", false, "倒计时5秒时给t上盾和再生");
     }
     public override SortedList<DescType, string> DescriptionDict => new()
     {
-        {DescType.HealArea, $"GCD: {AfflatusRapture}, {Medica2}, {Cure3}, {Medica}\n                     能力: {Asylum}, {Assize}"},
-        {DescType.HealSingle, $"GCD: {AfflatusSolace}, {Regen}, {Cure2}, {Cure}\n                     能力: {Tetragrammaton}"},
+        {DescType.HealArea, $"GCD: {AfflatusRapture}, {Medica2}, {Cure3}, {Medica}\n                     能力: {Asylum}"},
+        {DescType.HealSingle, $"GCD: {AfflatusSolace}, {Regen}, {Cure2}, {Cure}\n                     能力: {Tetragrammaton},{DivineBenison}"},
         {DescType.DefenseArea, $"{Temperance}, {LiturgyoftheBell}"},
         {DescType.DefenseSingle, $"{DivineBenison}, {Aquaveil}"},
     };
@@ -43,7 +43,7 @@ internal sealed class WHMCombo_Default : WHMCombo_Base<CommandType>
         //泄蓝花 团队缺血时优先狂喜之心
         bool liliesNearlyFull = Lily == 2 && LilyAfter(17);
         bool liliesFullNoBlood = Lily == 3 && BloodLily < 3;
-        if (Config.GetBoolByName("UseLilyWhenFull") && (liliesNearlyFull || liliesFullNoBlood))
+        if (Config.GetBoolByName("UseLilyWhenFull") && (liliesNearlyFull || liliesFullNoBlood) && AfflatusMisery.EnoughLevel)
         {
             if (TargetUpdater.PartyMembersAverHP < 0.7)
             {
@@ -71,7 +71,7 @@ internal sealed class WHMCombo_Default : WHMCombo_Base<CommandType>
         if (PresenseOfMind.ShouldUse(out act)) return true;
 
         //加个法令
-        if (Assize.ShouldUse(out act, mustUse: true)) return true;
+        if (HaveHostilesInRange && Assize.ShouldUse(out act, mustUse: true)) return true;
 
         return false;
     }
@@ -97,7 +97,7 @@ internal sealed class WHMCombo_Default : WHMCombo_Base<CommandType>
         if (AfflatusSolace.ShouldUse(out act)) return true;
 
         //再生
-        if (Regen.ShouldUse(out act)) return true;
+        if (Regen.Target.GetHealthRatio() > 0.4 && Regen.ShouldUse(out act)) return true;
 
         //救疗
         if (Cure2.ShouldUse(out act)) return true;
@@ -114,15 +114,14 @@ internal sealed class WHMCombo_Default : WHMCombo_Base<CommandType>
         if (Benediction.Target.GetHealthRatio() < 0.3
             && Benediction.ShouldUse(out act)) return true;
 
+        //庇护所
+        if (!IsMoving && Asylum.ShouldUse(out act)) return true;
+
+        //神祝祷
+        if (DivineBenison.ShouldUse(out act)) return true;
+
         //神名
         if (Tetragrammaton.ShouldUse(out act)) return true;
-
-        //庇护所
-        if (Asylum.ShouldUse(out act)) return true;
-
-        //天赐
-        if (Benediction.ShouldUse(out act)) return true;
-
         return false;
     }
 
@@ -174,6 +173,7 @@ internal sealed class WHMCombo_Default : WHMCombo_Base<CommandType>
         if (LiturgyoftheBell.ShouldUse(out act)) return true;
         return false;
     }
+
     //开局5s使用再生和盾给开了盾姿的t
     private protected override IAction CountDownAction(float remainTime)
     {

--- a/XIVAutoAttack/Combos/Melee/RPRCombos/RPRCombo_Default.cs
+++ b/XIVAutoAttack/Combos/Melee/RPRCombos/RPRCombo_Default.cs
@@ -91,7 +91,7 @@ internal sealed class RPRCombo_Default : RPRCombo_Base<CommandType>
                 if (Config.GetBoolByName("EnshroudPooling") && PlentifulHarvest.EnoughLevel && ArcaneCircle.WillHaveOneCharge(9) &&
                    ((LemureShroud == 4 && Target.WillStatusEnd(30, true, StatusID.DeathsDesign)) || (LemureShroud == 3 && Target.WillStatusEnd(50, true, StatusID.DeathsDesign)))) //双附体窗口期 
                 {
-                    if (ShadowofDeath.ShouldUse(out act)) return true;
+                    if (ShadowofDeath.ShouldUse(out act, mustUse: true)) return true;
                 }
 
                 //夜游魂衣-虚无/交错收割 阴冷收割

--- a/XIVAutoAttack/Combos/Melee/SAMCombos/SAMCombo_Default.cs
+++ b/XIVAutoAttack/Combos/Melee/SAMCombos/SAMCombo_Default.cs
@@ -166,8 +166,8 @@ internal sealed class SAMCombo_Default : SAMCombo_Base<CommandType>
     private protected override bool EmergencyAbility(byte abilityRemain, IAction nextGCD, out IAction act)
     {
         //明镜止水
-        if (HaveHostilesInRange && (!IsLastGCD(true, Shifu, Jinpu, Hakaze, Fuga) || IsLastGCD(true, Yukikaze, Mangetsu, Oka)) &&
-            HasSetsu && (IsTargetBoss ? ((Target.HasStatus(true, StatusID.Higanbana) && !Target.WillStatusEnd(40, true, StatusID.Higanbana)) || (!HaveMoon && !HaveFlower)) : true))
+        if (HaveHostilesInRange && IsLastGCD(true, Yukikaze, Mangetsu, Oka) && 
+            (IsTargetBoss ? ((Target.HasStatus(true, StatusID.Higanbana) && !Target.WillStatusEnd(40, true, StatusID.Higanbana)) || (!HaveMoon && !HaveFlower)) : true))
         {
             if (MeikyoShisui.ShouldUse(out act, emptyOrSkipCombo: true)) return true;
         }


### PR DESCRIPTION
白魔：
优化再生使用条件判断
神祝祷修改为只对坦克职业释放
现在不会在未学习苦难之心的情况下泄蓝花了
武士：
优化aoe连时的明镜止水使用条件判断
镰刀：
加回了被秋水删掉的某个mustuse