### PR TITLE
武士镰刀更新

### DIFF
--- a/XIVAutoAttack/Combos/Basic/RPRCombo_Base.cs
+++ b/XIVAutoAttack/Combos/Basic/RPRCombo_Base.cs
@@ -261,6 +261,25 @@ internal abstract class RPRCombo_Base<TCmd> : CustomCombo<TCmd> where TCmd : Enu
     /// 勾刃
     /// </summary>
     public static BaseAction Harpe { get; } = new(ActionID.Harpe);
+
+    /// <summary>
+    /// 地狱入境
+    /// </summary>
+    public static BaseAction HellsIngress { get; } = new(ActionID.HellsIngress)
+    {
+        BuffsProvide = new[] { StatusID.EnhancedHarpe },
+        ActionCheck = b => !Player.HasStatus(true, StatusID.Bind1, StatusID.Bind2)
+    };
+
+    /// <summary>
+    /// 地狱出境
+    /// </summary>
+    public static BaseAction HellsEgress { get; } = new(ActionID.HellsEgress)
+    {
+        BuffsProvide = HellsIngress.BuffsProvide,
+        ActionCheck = HellsIngress.ActionCheck
+    };
+
     /// <summary>
     /// 播魂种
     /// </summary>

--- a/XIVAutoAttack/Combos/Basic/SAMCombo_Base.cs
+++ b/XIVAutoAttack/Combos/Basic/SAMCombo_Base.cs
@@ -49,7 +49,9 @@ internal abstract class SAMCombo_Base<TCmd> : CustomCombo<TCmd> where TCmd : Enu
     protected static byte SenCount => (byte)((HasGetsu ? 1 : 0) + (HasSetsu ? 1 : 0) + (HasKa ? 1 : 0));
 
     protected static bool HaveMoon => Player.HasStatus(true, StatusID.Fugetsu);
+    protected static float MoonTime => Player.StatusTime(true, StatusID.Fugetsu);
     protected static bool HaveFlower => Player.HasStatus(true, StatusID.Fuka);
+    protected static float FlowerTime => Player.StatusTime(true, StatusID.Fuka);
 
     #region 单体
     /// <summary>
@@ -106,12 +108,23 @@ internal abstract class SAMCombo_Base<TCmd> : CustomCombo<TCmd> where TCmd : Enu
     /// <summary>
     /// 满月
     /// </summary>
-    public static BaseAction Mangetsu { get; } = new(ActionID.Mangetsu);
-
+    public static BaseAction Mangetsu { get; } = new(ActionID.Mangetsu)
+    {
+        OtherIDsCombo = new[]
+        {
+            ActionID.Fuga,ActionID.Fuko
+        }
+    };
     /// <summary>
     /// 樱花
     /// </summary>
-    public static BaseAction Oka { get; } = new(ActionID.Oka);
+    public static BaseAction Oka { get; } = new(ActionID.Oka)
+    {
+        OtherIDsCombo = new[]
+        {
+            ActionID.Fuga,ActionID.Fuko
+        }
+    };
 
     /// <summary>
     /// 无明照破
@@ -229,7 +242,15 @@ internal abstract class SAMCombo_Base<TCmd> : CustomCombo<TCmd> where TCmd : Enu
     /// </summary>
     public static BaseAction HissatsuGyoten { get; } = new(ActionID.HissatsuGyoten)
     {
-        ActionCheck = b => !Player.HasStatus(true, StatusID.Bind1, StatusID.Bind2)
+        ActionCheck = b => Kenki >=10 && !Player.HasStatus(true, StatusID.Bind1, StatusID.Bind2)
+    };
+
+    /// <summary>
+    /// 必杀剑·夜天
+    /// </summary>
+    public static BaseAction HissatsuYaten { get; } = new(ActionID.HissatsuYaten)
+    {
+        ActionCheck = HissatsuGyoten.ActionCheck
     };
 
     /// <summary>

--- a/XIVAutoAttack/Combos/Melee/RPRCombos/RPRCombo_Default.cs
+++ b/XIVAutoAttack/Combos/Melee/RPRCombos/RPRCombo_Default.cs
@@ -46,7 +46,8 @@ internal sealed class RPRCombo_Default : RPRCombo_Base<CommandType>
     };
     public override SortedList<DescType, string> DescriptionDict => new()
     {
-        {DescType.DefenseSingle, $"{ArcaneCrest}"},
+        {DescType.DefenseSingle, $"能力: {ArcaneCrest}"},
+        {DescType.MoveAction, $"能力: {HellsIngress}, "},
     };
     private protected override IAction CountDownAction(float remainTime)
     {
@@ -166,7 +167,8 @@ internal sealed class RPRCombo_Default : RPRCombo_Base<CommandType>
             //神秘环
             if (ArcaneCircle.ShouldUse(out act)) return true;
 
-            if ((!Config.GetBoolByName("EnshroudPooling") && Shroud >= 50) ||//未开启双附体
+            if ((IsTargetBoss&& IsTargetDying) || //资源倾泻
+               (!Config.GetBoolByName("EnshroudPooling") && Shroud >= 50) ||//未开启双附体
                (Config.GetBoolByName("EnshroudPooling") && Shroud >= 50 &&
                (!PlentifulHarvest.EnoughLevel || //等级不足以双附体
                Player.HasStatus(true, StatusID.ArcaneCircle) || //在神秘环期间附体
@@ -196,6 +198,13 @@ internal sealed class RPRCombo_Default : RPRCombo_Base<CommandType>
         if (GrimSwathe.ShouldUse(out act)) return true;
         //单体
         if (BloodStalk.ShouldUse(out act)) return true;
+        return false;
+    }
+
+    private protected override bool MoveGCD(out IAction act)
+    {
+        //E上去
+        if (HellsIngress.ShouldUse(out act)) return true;
         return false;
     }
 

--- a/XIVAutoAttack/Data/ActionID.cs
+++ b/XIVAutoAttack/Data/ActionID.cs
@@ -2392,6 +2392,16 @@ namespace XIVAutoAttack.Data
         LemuresScythe = 24400,
 
         /// <summary>
+        /// 地狱入境
+        /// </summary>
+        HellsIngress = 24401,
+
+        /// <summary>
+        /// 地狱出境
+        /// </summary>
+        HellsEgress = 24402,
+
+        /// <summary>
         /// 虚无收割
         /// </summary>
         VoidReaping = 24395,
@@ -2517,6 +2527,11 @@ namespace XIVAutoAttack.Data
         /// 必杀剑·晓天
         /// </summary>
         HissatsuGyoten = 7492,
+
+        /// <summary>
+        /// 必杀剑·夜天
+        /// </summary>
+        HissatsuYaten = 7493,
 
         /// <summary>
         /// 必杀剑·震天

--- a/XIVAutoAttack/Windows/ComboConfigWindow/ComboConfigWindow_About.cs
+++ b/XIVAutoAttack/Windows/ComboConfigWindow/ComboConfigWindow_About.cs
@@ -15,7 +15,7 @@ internal partial class ComboConfigWindow
             ImGui.TextColored(ImGuiColors.DalamudRed, LocalizationManager.RightLang.Configwindow_About_Declaration);
             ImGui.Spacing();
             ImGui.TextColored(ImGuiColors.DalamudRed, LocalizationManager.RightLang.Configwindow_About_XianYu);
-            ImGui.TextColored(ImGuiColors.DalamudYellow, "五颜六色的猪  小玉超可爱  纷乱雪月花  EmetSelch  麦麦麦麦  叶怀雨雨");
+            ImGui.TextColored(ImGuiColors.DalamudYellow, "五颜六色的猪  小玉超可爱  纷乱雪月花  叶怀雨雨\nff14最后一个机工士  用户_163750520");
             ImGui.Spacing();
             ImGui.Spacing();
             ImGui.TextWrapped(LocalizationManager.RightLang.Configwindow_About_Owner);


### PR DESCRIPTION
武士：
基础连击逻辑全部重写
修复AoE连击问题
月闪和花闪现在会智能选择先打buff时间更少的一个
BOSS快死时自动使用明镜止水来倾泻资源
优化了部分技能的条件判断
加回了位移技能
镰刀：
BOSS快死时自动使用附体来倾泻资源
加回了位移技能