### PR TITLE
Various optimisations for DRK rotation

### DIFF
--- a/RotationSolver.Default/Tank/DRK_Balance.cs
+++ b/RotationSolver.Default/Tank/DRK_Balance.cs
@@ -1,0 +1,195 @@
+namespace RotationSolver.Balance.Tank;
+
+
+[RotationDesc(ActionID.BloodWeapon, ActionID.Delirium)]
+[SourceCode("https://github.com/ArchiDog1998/RotationSolver/blob/main/RotationSolver.Default/Tank/DRK_Default.cs")]
+[LinkDescription("https://www.thebalanceffxiv.com/img/jobs/drk/drk_standard_6.2_v1.png")]
+public sealed class DRK_Balance : DRK_Base
+{
+    public override string GameVersion => "6.31";
+
+    public override string RotationName => "Balance";
+
+    protected override bool CanHealSingleAbility => false;
+
+    private static bool InDeliruim => !Delirium.EnoughLevel || Delirium.IsCoolingDown && Delirium.ElapsedOneChargeAfterGCD(1) && !Delirium.ElapsedOneChargeAfterGCD(7);
+
+    private static bool InTwoMinBurst => BloodWeapon.IsCoolingDown && Delirium.IsCoolingDown && (LivingShadow.IsCoolingDown && !(LivingShadow.ElapsedAfter(20)));
+
+    private static bool CombatLess => CombatElapsedLess(3);
+
+    private bool CheckDarkSide
+    {
+        get
+        {
+            if (DarkSideEndAfterGCD(3)) return true;
+
+            if (CombatLess) return false;
+
+            if ((InTwoMinBurst && SaltedEarth.IsCoolingDown && ShadowBringer.CurrentCharges==0 && CarveandSpit.IsCoolingDown) || HasDarkArts) return true;
+
+            if (Configs.GetBool("TheBlackestNight") && Player.CurrentMp < 6000) return false;
+
+            return Player.CurrentMp >= 8500;
+        }
+    }
+
+    private bool UseBlood
+    {
+        get
+        {
+            if (!Delirium.EnoughLevel) return true;
+
+            if (Player.HasStatus(true, StatusID.Delirium) && Player.StatusStack(true, StatusID.BloodWeapon) < 2) return true;
+
+            if (BloodWeapon.WillHaveOneChargeGCD(1) || Blood >= 90 && !Player.HasStatus(true, StatusID.Delirium)) return true;
+
+            return false;
+        }
+    }
+
+    protected override IRotationConfigSet CreateConfiguration()
+        => base.CreateConfiguration()
+            .SetBool("TheBlackestNight", true, "Keep 3000 MP");
+
+    protected override IAction CountDownAction(float remainTime)
+    {
+        //Provoke when has Shield.
+        if(remainTime <= Service.Config.CountDownAhead)
+        {
+            if (HasTankStance)
+            {
+                if (Provoke.CanUse(out var act1)) return act1;
+            }
+            else
+            {
+                if (Unmend.CanUse(out var act1)) return act1;
+            }
+        }
+        if (remainTime <= 2 && UseBurstMedicine(out var act)) return act;
+        if (remainTime <= 3 && TheBlackestNight.CanUse(out act)) return act;
+        if (remainTime <= 4 && BloodWeapon.CanUse(out act)) return act;
+        return base.CountDownAction(remainTime);
+    }
+
+    [RotationDesc(ActionID.TheBlackestNight)]
+    protected override bool HealSingleAbility(byte abilitiesRemaining, out IAction act)
+    {
+        if (TheBlackestNight.CanUse(out act)) return true;
+
+        return false;
+    }
+
+    [RotationDesc(ActionID.DarkMissionary, ActionID.Reprisal)]
+    protected override bool DefenseAreaAbility(byte abilitiesRemaining, out IAction act)
+    {
+        if (DarkMissionary.CanUse(out act)) return true;
+        if (Reprisal.CanUse(out act, CanUseOption.MustUse)) return true;
+
+        return false;
+    }
+
+    [RotationDesc(ActionID.TheBlackestNight, ActionID.Oblation, ActionID.ShadowWall, ActionID.Rampart, ActionID.DarkMind, ActionID.Reprisal)]
+    protected override bool DefenseSingleAbility(byte abilitiesRemaining, out IAction act)
+    {
+        act = null;
+
+        if (Player.HasStatus(true, StatusID.TheBlackestNight)) return false;
+
+        if (abilitiesRemaining == 1)
+        {
+            //10
+            if (Oblation.CanUse(out act, CanUseOption.EmptyOrSkipCombo)) return true;
+
+            if (Reprisal.CanUse(out act, CanUseOption.MustUse)) return true;
+
+            if (TheBlackestNight.CanUse(out act)) return true;
+        }
+        else
+        {
+            //30
+            if ((!Rampart.IsCoolingDown || Rampart.ElapsedAfter(60)) && (ShadowWall.CanUse(out act))) return true;
+
+            //20
+            if ((ShadowWall.IsCoolingDown && ShadowWall.ElapsedAfter(60)) && (Rampart.CanUse(out act))) return true;
+            if (DarkMind.CanUse(out act)) return true;
+        }
+
+        return false;
+    }
+
+    protected override bool GeneralGCD(out IAction act)
+    {
+        if (IsMoving && HasHostilesInRange && BloodWeapon.CanUse(out act)) return true;
+
+        //Use Blood
+        if (UseBlood)
+        {
+            if (Quietus.CanUse(out act)) return true;
+            if (BloodSpiller.CanUse(out act)) return true;
+        }
+
+        //AOE
+        if (StalwartSoul.CanUse(out act)) return true;
+        if (Unleash.CanUse(out act)) return true;
+
+        //单体
+        if (Souleater.CanUse(out act)) return true;
+        if (SyphonStrike.CanUse(out act)) return true;
+        if (HardSlash.CanUse(out act)) return true;
+
+        if (SpecialType == SpecialCommandType.MoveForward && MoveForwardAbility(1, out act)) return true;
+        if (Unmend.CanUse(out act)) return true;
+
+        return false;
+    }
+
+    protected override bool AttackAbility(byte abilitiesRemaining, out IAction act)
+    {
+        if (CheckDarkSide)
+        {
+            if (FloodOfDarkness.CanUse(out act)) return true;
+            if (EdgeOfDarkness.CanUse(out act)) return true;
+        }
+
+        if (InBurst)
+        {
+            if (UseBurstMedicine(out act)) return true;
+            if (BloodWeapon.CanUse(out act)) return true;
+            if (Delirium.CanUse(out act)) return true;
+            if (LivingShadow.CanUse(out act, CanUseOption.MustUse)) return true;
+        }
+
+        if (CombatLess)
+        {
+            act = null;
+            return false;
+        }
+
+        if (!IsMoving && SaltedEarth.CanUse(out act, CanUseOption.MustUse)) return true;
+
+        if (InTwoMinBurst)
+        {
+            if (ShadowBringer.CanUse(out act, CanUseOption.MustUse)) return true;
+        }
+
+        if (AbyssalDrain.CanUse(out act)) return true;
+        if (CarveandSpit.CanUse(out act)) return true;
+
+        if (InTwoMinBurst)
+        {
+            if (ShadowBringer.CanUse(out act, CanUseOption.MustUse | CanUseOption.EmptyOrSkipCombo)) return true;
+
+            if (Plunge.CanUse(out act, CanUseOption.MustUse) && !IsMoving) return true;
+        }
+
+        if (SaltandDarkness.CanUse(out act)) return true;
+
+        if (InTwoMinBurst)
+        {
+            if (Plunge.CanUse(out act, CanUseOption.MustUse | CanUseOption.EmptyOrSkipCombo) && !IsMoving) return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Here's a list of the changes I made:
- Incorporated various rotation rules from The Balance: added resource pooling, added two minute burst window, using ShadowBringer and Plunge only during 2 minute burst
- Two minute Burst: First 20 seconds after using Living Shadow
- Resource pooling: Will only expend all mana and blood during two minute burst, otherwise will only spend them to prevent overcap
- oGCD rotation: Will use SaltandDarkness, CarveandSpit/AbyssalDrain, etc on cooldown after opener, but will only use Shadowbringer and Plunge during two minute burst window (as suggested in The Balance)
- Aligned oGCD order to follow The Balance (https://www.thebalanceffxiv.com/jobs/tanks/dark-knight/openers/) so that it will first ensure all oGCDs go on cooldown before dumping mana and using second charges of 2-charge-oGCDs
- Added early use of BloodWeapon to ensure LivingShadow is always used after the third GCD (currently being used on the 4th when there is no countdown)
- Finally a few defensive CD changes - added protection from using 30% and 20% CDs within 1 minute of each other, changed order so Oblation and Reprisal are used before TBN so the shield is boosted, added Reprisal to MustUse