### PR TITLE
Added missing DRG status

### DIFF
--- a/RotationSolver.Basic/Data/StatusID.cs
+++ b/RotationSolver.Basic/Data/StatusID.cs
@@ -199,6 +199,8 @@ public enum StatusID : ushort
 
     RightEye = 1910,
 
+    DraconianFire = 1863,
+
     #region MNK
     OpoOpoForm = 107,
 

--- a/RotationSolver.Basic/Data/StatusID.cs
+++ b/RotationSolver.Basic/Data/StatusID.cs
@@ -201,6 +201,8 @@ public enum StatusID : ushort
 
     DraconianFire = 1863,
 
+    ChaoticSpring = 2719,
+
     #region MNK
     OpoOpoForm = 107,
 

--- a/RotationSolver.Basic/Data/StatusID.cs
+++ b/RotationSolver.Basic/Data/StatusID.cs
@@ -203,6 +203,8 @@ public enum StatusID : ushort
 
     ChaoticSpring = 2719,
 
+    ChaosThrust = 118,
+
     #region MNK
     OpoOpoForm = 107,
 


### PR DESCRIPTION
Draconian Fire status was missing. This is given after finishing 123 rotation and enables Raiden Thrust and Draconian Fury.

Edit: Added the detrimental status effects on target for Chaotic Spring and Chaos Thrust.