### PR TITLE
Fix for broken Simulate Keypresses.

### DIFF
--- a/RotationSolver/Commands/RSCommands_Actions.cs
+++ b/RotationSolver/Commands/RSCommands_Actions.cs
@@ -46,10 +46,10 @@ namespace RotationSolver.Commands
                 return;
             }
 
-            if (!isGCD && nextAction is BaseAction act1 && act1.IsRealGCD) return;
-
             if (Service.Config.KeyBoardNoise)
                 PreviewUpdater.PulseActionBar(nextAction.AdjustedID);
+
+            if (!isGCD && nextAction is BaseAction act1 && act1.IsRealGCD) return;
 
             if (nextAction.Use() && nextAction is BaseAction act)
             {


### PR DESCRIPTION
The old way it would only ever start the task if 
`if (!isGCD && nextAction is BaseAction act1 && act1.IsRealGCD) return;`
was false. Meaning while globals were on cooldown it would never simulate a keypress.