### PR TITLE
Fixed broken target condition, added a target condition for comparing casting time.

### DIFF
--- a/RotationSolver/Localization/EnumTranslations.cs
+++ b/RotationSolver/Localization/EnumTranslations.cs
@@ -15,6 +15,7 @@ internal static class EnumTranslations
         TargetConditionType.StatusEnd => LocalizationManager.RightLang.TargetConditionType_StatusEnd,
         TargetConditionType.StatusEndGCD => LocalizationManager.RightLang.TargetConditionType_StatusEndGCD,
         TargetConditionType.CastingAction => LocalizationManager.RightLang.TargetConditionType_CastingAction,
+        TargetConditionType.CastingActionTimeUntil => LocalizationManager.RightLang.TargetConditionType_CastingActionTimeUntil,
         _ => string.Empty,
     };
 

--- a/RotationSolver/Localization/Localization.json
+++ b/RotationSolver/Localization/Localization.json
@@ -272,6 +272,7 @@
   "TargetConditionType_StatusEnd": "Status End",
   "TargetConditionType_StatusEndGCD": "Status End GCD",
   "TargetConditionType_CastingAction": "Casting Action",
+  "TargetConditionType_CastingActionTimeUntil": "Casting Action Time Until",
   "DescType_BurstActions": "Burst Actions",
   "DescType_MoveForwardGCD": "Move Forward GCD",
   "DescType_HealAreaGCD": "Area Healing GCD",

--- a/RotationSolver/Localization/Strings.cs
+++ b/RotationSolver/Localization/Strings.cs
@@ -368,6 +368,7 @@ internal partial class Strings
     public string TargetConditionType_StatusEnd { get; set; } = "Status End";
     public string TargetConditionType_StatusEndGCD { get; set; } = "Status End GCD";
     public string TargetConditionType_CastingAction { get; set; } = "Casting Action";
+    public string TargetConditionType_CastingActionTimeUntil { get; set; } = "Casting Action Time Until";
 
     #endregion
 

--- a/RotationSolver/Localization/de.json
+++ b/RotationSolver/Localization/de.json
@@ -272,6 +272,7 @@
   "TargetConditionType_StatusEnd": "Status End",
   "TargetConditionType_StatusEndGCD": "Status End GCD",
   "TargetConditionType_CastingAction": "Casting Action",
+  "TargetConditionType_CastingActionTimeUntil": "Casting Action Time Until",
   "DescType_BurstActions": "Burst Actions",
   "DescType_MoveForwardGCD": "Move Forward GCD",
   "DescType_HealAreaGCD": "Area Healing GCD",

--- a/RotationSolver/Localization/es.json
+++ b/RotationSolver/Localization/es.json
@@ -272,6 +272,7 @@
   "TargetConditionType_StatusEnd": "Status End",
   "TargetConditionType_StatusEndGCD": "Status End GCD",
   "TargetConditionType_CastingAction": "Casting Action",
+  "TargetConditionType_CastingActionTimeUntil": "Casting Action Time Until",
   "DescType_BurstActions": "Burst Actions",
   "DescType_MoveForwardGCD": "Move Forward GCD",
   "DescType_HealAreaGCD": "Area Healing GCD",

--- a/RotationSolver/Localization/fr.json
+++ b/RotationSolver/Localization/fr.json
@@ -272,6 +272,7 @@
   "TargetConditionType_StatusEnd": "Status End",
   "TargetConditionType_StatusEndGCD": "Status End GCD",
   "TargetConditionType_CastingAction": "Casting Action",
+  "TargetConditionType_CastingActionTimeUntil": "Casting Action Time Until",
   "DescType_BurstActions": "Burst Actions",
   "DescType_MoveForwardGCD": "Move Forward GCD",
   "DescType_HealAreaGCD": "Area Healing GCD",

--- a/RotationSolver/Localization/ja.json
+++ b/RotationSolver/Localization/ja.json
@@ -272,6 +272,7 @@
   "TargetConditionType_StatusEnd": "Status End",
   "TargetConditionType_StatusEndGCD": "Status End GCD",
   "TargetConditionType_CastingAction": "Casting Action",
+  "TargetConditionType_CastingActionTimeUntil": "Casting Action Time Until",
   "DescType_BurstActions": "Burst Actions",
   "DescType_MoveForwardGCD": "Move Forward GCD",
   "DescType_HealAreaGCD": "Area Healing GCD",

--- a/RotationSolver/Timeline/TargetCondition.cs
+++ b/RotationSolver/Timeline/TargetCondition.cs
@@ -34,6 +34,7 @@ internal class TargetCondition : ICondition
     public int Ability;
 
     public string CastingActionName = string.Empty;
+    public float CastingActionTime = 0f;
 
     public bool IsTrue(ICustomRotation combo)
     {
@@ -91,6 +92,17 @@ internal class TargetCondition : ICondition
                 var castName = Service.GetSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(tar.CastActionId)?.Name.ToString();
 
                 result = CastingActionName == castName;
+                break;
+
+            case TargetConditionType.CastingActionTimeUntil:
+                if (CastingActionTime <= 0f || !tar.IsCasting)
+                {
+                    result = false;
+                    break;
+                }
+
+                var castTime = tar.TotalCastTime - tar.CurrentCastTime;
+                result = castTime < CastingActionTime;
                 break;
         }
 
@@ -169,6 +181,7 @@ internal class TargetCondition : ICondition
                 };
                 break;
 
+            case TargetConditionType.CastingActionTimeUntil:
             case TargetConditionType.Distance:
             case TargetConditionType.StatusEnd:
                 combos = new string[] { ">", "<=" };
@@ -255,6 +268,11 @@ internal class TargetCondition : ICondition
                 ImGui.SameLine();
                 ImGui.InputText($"##CastingActionName{GetHashCode()}", ref CastingActionName, 100);
                 break;
+
+            case TargetConditionType.CastingActionTimeUntil:
+                ImGui.SameLine();
+                ConditionHelper.DrawDragFloat($"s##CastingActionTime{GetHashCode()}", ref CastingActionTime);
+                break;
         }
     }
 }
@@ -268,4 +286,5 @@ public enum TargetConditionType : int
     StatusEnd,
     StatusEndGCD,
     CastingAction,
+    CastingActionTimeUntil
 }

--- a/RotationSolver/Timeline/TargetCondition.cs
+++ b/RotationSolver/Timeline/TargetCondition.cs
@@ -253,7 +253,7 @@ internal class TargetCondition : ICondition
 
             case TargetConditionType.CastingAction:
                 ImGui.SameLine();
-                ImGui.InputText("##CastingActionName", ref CastingActionName, 100);
+                ImGui.InputText($"##CastingActionName{GetHashCode()}", ref CastingActionName, 100);
                 break;
         }
     }


### PR DESCRIPTION
CastingActionName was missing a hash so you could not have multiple of these. They would overwrite eachother.
Also added a new target condition so users can do something like:

If target is casting Aerial Blast, and remaining cast time is less than 2 seconds, use this ability.