### PR TITLE
fix!: Broken release (DisabledAction)

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction_ActionInfo.cs
+++ b/RotationSolver.Basic/Actions/BaseAction_ActionInfo.cs
@@ -52,7 +52,8 @@ public partial class BaseAction
 
         if (!option.HasFlag(CanUseOption.SkipDisable) && !IsEnabled) return false;
 
-        if (DataCenter.DisabledAction.Contains(ID)) return false;
+        
+        if (DataCenter.DisabledAction != null && DataCenter.DisabledAction.Contains(ID)) return false;
 
         if (ConfigurationHelper.BadStatus.Contains(ActionManager.Instance()->GetActionStatus(ActionType.Spell, AdjustedID)))
             return false;

--- a/RotationSolver.Basic/Actions/BaseItem.cs
+++ b/RotationSolver.Basic/Actions/BaseItem.cs
@@ -85,7 +85,7 @@ public class BaseItem : IBaseItem
         item = this;
         if (_item == null) return false;
         if (!CanUseThis) return false;
-        if (DataCenter.DisabledAction.Contains(ID)) return false;
+        if (DataCenter.DisabledAction != null && DataCenter.DisabledAction.Contains(ID)) return false;
         if(!IsEnabled) return false;
 
         if (ConfigurationHelper.BadStatus.Contains(ActionManager.Instance()->GetActionStatus(ActionType.Item, ID))

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -229,7 +229,9 @@ internal static partial class TargetUpdater
         DataCenter.PartyMembers = GetPartyMembers(allTargets);
         DataCenter.AllianceMembers = allTargets.OfType<PlayerCharacter>();
 
-        DataCenter.HasPet = HasPet();
+        var mayPet = allTargets.OfType<BattleNpc>().Where(npc => npc.OwnerId == Service.Player.ObjectId);
+        DataCenter.HasPet = mayPet.Any(npc => npc.BattleNpcKind == BattleNpcSubKind.Pet);
+        //DataCenter.HasPet = HasPet();
 
         DataCenter.PartyTanks = DataCenter.PartyMembers.GetJobCategory(JobRole.Tank);
         DataCenter.PartyHealers = DataCenter.PartyMembers.GetJobCategory(JobRole.Healer);


### PR DESCRIPTION
Includes a null check so the whole plogon doesn't crash. The reason it was working for some of us was because we had saved Action Sequence json files that would load at startup and initiate UpdateActionSequencerAction(), thus making sure our DataCenter.DisabledAction was not null.