### PR TITLE
feat: Added auto load feature for local third-party files.

### DIFF
--- a/RotationSolver.Basic/Configuration/PluginConfiguration.cs
+++ b/RotationSolver.Basic/Configuration/PluginConfiguration.cs
@@ -205,6 +205,7 @@ public class PluginConfiguration : IPluginConfiguration
     public int MaxPing = 300;
 
     public bool ShowStatusWindow = false;
+    public bool AutoLoadCustomRotations = false;
 
     public void Save()
     {

--- a/RotationSolver.Basic/Data/RSCommandType.cs
+++ b/RotationSolver.Basic/Data/RSCommandType.cs
@@ -47,7 +47,8 @@ public enum SettingsCommand : byte
     UseAOEAction,
     UseAOEWhenManual,
     PreventActions,
-    PreventActionsDuty
+    PreventActionsDuty,
+    AutoLoadCustomRotations,
 }
 
 public static class SettingsCommandExtension

--- a/RotationSolver/RotationHelper.cs
+++ b/RotationSolver/RotationHelper.cs
@@ -91,6 +91,9 @@ internal static class RotationHelper
             }
             using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
             var assembly = LoadFromStream(file, pdbFile);
+
+            file.Dispose();
+            pdbFile.Dispose();
             return assembly;
         }
     }
@@ -180,17 +183,5 @@ internal static class RotationHelper
         LoadedCustomRotations.Add(loaded);
         
         return assembly;
-    }
-
-    public static string GetFileMD5Hash(string filePath)
-    {
-        using (var md5 = MD5.Create())
-        {
-            using (var stream = File.OpenRead(filePath))
-            {
-                byte[] hashBytes = md5.ComputeHash(stream);
-                return BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
-            }
-        }
     }
 }

--- a/RotationSolver/UI/RotationConfigWindow_List.cs
+++ b/RotationSolver/UI/RotationConfigWindow_List.cs
@@ -240,6 +240,9 @@ internal partial class RotationConfigWindow
                 ImGuiHelper.Spacing();
 
                 ImGui.TextWrapped("Third-party Rotation Libraries");
+
+                ImGui.Checkbox("Auto load rotations",
+                    ref Service.Config.AutoLoadCustomRotations);
             });
 
             ImGui.EndTabBar();

--- a/RotationSolver/Updaters/MajorUpdater.cs
+++ b/RotationSolver/Updaters/MajorUpdater.cs
@@ -101,8 +101,14 @@ internal static class MajorUpdater
         {
             PreviewUpdater.UpdateCastBarState();
             TargetUpdater.UpdateTarget();
+            
+            if (Service.Config.AutoLoadCustomRotations)
+            {
+                RotationUpdater.LocalRotationWatcher();
+            }
 
             RotationUpdater.UpdateRotation();
+            
 
             ActionSequencerUpdater.UpdateActionSequencerAction();
             ActionUpdater.UpdateNextAction();
@@ -118,6 +124,8 @@ internal static class MajorUpdater
 
         _work = false;
     }
+
+
 
     public static void Dispose()
     {

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -204,6 +204,7 @@ internal static class RotationUpdater
 
         foreach (var dir in dirs)
         {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
             var dlls = Directory.GetFiles(dir, "*.dll");
             
             foreach (var dll in dlls)

--- a/RotationSolver/Updaters/RotationUpdater.cs
+++ b/RotationSolver/Updaters/RotationUpdater.cs
@@ -216,12 +216,7 @@ internal static class RotationUpdater
 
                 if (index == -1)
                 {
-                    PluginLog.LogWarning("Loading: " + dll);
                     GetAllCustomRotations(DownloadOption.Local);
-                }
-                else
-                {
-                    PluginLog.LogWarning("Already loaded: " + dll);
                 }
             }
         }


### PR DESCRIPTION
Checks if file has been modified. Less resource-intensive than checking MD5. Due to the way RotationUpdater and RotationHelper currently loads files we limit this to every 2 seconds to prevent any noticeable FPS decrease.