### PR TITLE
fix: Do not automagically use True North if player has Right Eye status.

### DIFF
--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -264,7 +264,7 @@ public abstract partial class CustomRotation
             if (Configuration.PluginConfiguration.GetValue(SettingsCommand.AutoUseTrueNorth)
                 && action.EnemyPositional != EnemyPositional.None && action.Target != null)
             {
-                if (action.EnemyPositional != action.Target.FindEnemyPositional() && action.Target.HasPositional())
+                if (action.EnemyPositional != action.Target.FindEnemyPositional() && action.Target.HasPositional() && !Player.HasStatus(true, StatusID.RightEye))
                 {
                     if (TrueNorth.CanUse(out act, CanUseOption.EmptyOrSkipCombo | CanUseOption.OnLastAbility)) return true;
                 }

--- a/RotationSolver/UI/OverlayWindow.cs
+++ b/RotationSolver/UI/OverlayWindow.cs
@@ -167,11 +167,11 @@ internal static class OverlayWindow
 
         switch (shouldPos)
         {
-            case EnemyPositional.Flank when Service.Config.DrawPositional && !Player.Object.HasStatus(true, StatusID.TrueNorth):
+            case EnemyPositional.Flank when Service.Config.DrawPositional && CanDrawPositional(target):
                 DrawRange(ClosePoints(GetPtsOnScreen(SectorPlots(pPosition, radius, Math.PI * 0.25 + rotation, COUNT).Append(pPosition))), wrong);
                 DrawRange(ClosePoints(GetPtsOnScreen(SectorPlots(pPosition, radius, Math.PI * 1.25 + rotation, COUNT).Append(pPosition))), wrong);
                 break;
-            case EnemyPositional.Rear when Service.Config.DrawPositional && !Player.Object.HasStatus(true, StatusID.TrueNorth):
+            case EnemyPositional.Rear when Service.Config.DrawPositional && CanDrawPositional(target):
                 DrawRange(ClosePoints(GetPtsOnScreen(SectorPlots(pPosition, radius, Math.PI * 0.75 + rotation, COUNT).Append(pPosition))), wrong);
                 break;
 
@@ -182,7 +182,11 @@ internal static class OverlayWindow
                 }
                 break;
         }
+    }
 
+    private static bool CanDrawPositional(GameObject target)
+    {
+        return !Player.Object.HasStatus(true, StatusID.TrueNorth) && !Player.Object.HasStatus(true, StatusID.RightEye) && target.HasPositional();
     }
 
     static void DrawFill(Vector3[] pts1, Vector3[] pts2, Vector3 color)


### PR DESCRIPTION
Patch 6.4 brought Dragon Sight changes.